### PR TITLE
Remove invalid restrictive text

### DIFF
--- a/src/dsd-guide.adoc
+++ b/src/dsd-guide.adoc
@@ -175,10 +175,8 @@ pair -- and every even element of the total ``Package()`` -- is another
 ``Package()`` Data Structure.  Each UUID dictates the format and content
 of the Data Structure immediately following it.
 
-Only the well-known UUIDs and their corresponding Data Structures defined
-in this guide should be used.  The behavior of any other UUIDs and Data
-Structures are *undefined*.
-
+The use of the well-known UUIDs and their corresponding Data Structures,
+as defined in this document, is strongly recommended.
 
 ## Well-Known ``_DSD`` UUIDs and Data Structure Formats
 


### PR DESCRIPTION
In section 5, the document stated that it was the only source of valid
UUIDs for _DSD.  This is not correct.  There is at least one other
defined in the ACPI spec itself, and there could be more in the future.

So, removed the incorrect statements.

Signed-off-by: Al Stone <ahs3@redhat.com>